### PR TITLE
NFS removal (fix #27) - --generate-constants - EKS support - open up rpc

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include tqchain/deployment/*
+include tqchain/utils/*

--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ pip install -e ./
 
 ## private chain
 
+### Generate constants
+
+Your chain is uniquely defined by a set of values such as bootstrap account keys, chain id, timestamp...
+
+Create these values:
+
+``` shell
+mkchain --generate-constants $CHAIN_NAME
+```
+
+It will create two 2 yaml files, `<$CHAIN_NAME>_chain.yaml` and `<$CHAIN_NAME>_chain_invite.yaml`.
+
 ### create
 $CHAIN_NAME: is your private chain's name
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="mkchain",
     version="0.1",
     packages=['tqchain'],
-    package_data={'tqchain': ['deployment/*']},
+    include_package_data=True,
     install_requires=["pyyaml", "kubernetes"],
     entry_points={"console_scripts": ["mkchain=tqchain.mkchain:main"]},
 )

--- a/tqchain/deployment/activate.yaml
+++ b/tqchain/deployment/activate.yaml
@@ -9,6 +9,30 @@ spec:
       name: activate-job
     spec:
       initContainers:
+      - name: import-keys
+        command: ['sh', '-x', '/opt/tqtezos/import_keys.sh']
+        envFrom:
+        - secretRef:
+            name: tezos-secret
+        volumeMounts:
+        - name: tqtezos-utils
+          mountPath: /opt/tqtezos
+        - name: var-volume
+          mountPath: /var/tezos
+      - imagePullPolicy: Always
+        name: tezos-config-generator
+        image: python:alpine
+        command: ["python", "/opt/tqtezos/generateTezosConfig.py"]
+        envFrom:
+        - configMapRef:
+            name: tezos-config
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/tezos
+        - name: tqtezos-utils
+          mountPath: /opt/tqtezos
+        - name: var-volume
+          mountPath: /var/tezos
       - name: wait-for-node
         image: busybox
         command: ['sh', '-c', 'until nslookup tezos-rpc; do echo waiting for tezos-rpc; sleep 2; done;']
@@ -34,8 +58,9 @@ spec:
       restartPolicy: Never
       volumes:
       - name: config-volume
-        configMap:
-          name: tezos-config
+        emptyDir: {}
       - name: var-volume
-        persistentVolumeClaim:
-          claimName: tezos-pv-claim
+        emptyDir: {}
+      - name: tqtezos-utils
+        configMap:
+          name: tqtezos-utils

--- a/tqchain/deployment/common.yaml
+++ b/tqchain/deployment/common.yaml
@@ -9,15 +9,23 @@ metadata:
   name: tezos-pv-claim
   namespace: "tqtezos"
 spec:
-  storageClassName: manual
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
       storage: 15Gi
-  selector:
-    matchLabels:
-      storage-type: var-files
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tezos-secret
+  namespace: "tqtezos"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tqtezos-utils
+  namespace: "tqtezos"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -31,8 +39,10 @@ metadata:
   name: tezos-rpc
   namespace: "tqtezos"
 spec:
+  type: NodePort
   ports:
   - port: 8732
+    nodePort: 31732
   selector:
     app: tezos-node
 ---
@@ -65,6 +75,23 @@ spec:
       labels:
         app: tezos-node
     spec:
+      securityContext:
+        fsGroup: 100
+      initContainers:
+      - imagePullPolicy: Always
+        name: tezos-config-generator
+        image: python:alpine
+        command: ["python", "/opt/tqtezos/generateTezosConfig.py"]
+        envFrom:
+        - configMapRef:
+            name: tezos-config
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/tezos
+        - name: tqtezos-utils
+          mountPath: /opt/tqtezos
+        - name: var-volume
+          mountPath: /var/tezos
       containers:
       - imagePullPolicy: Always
         name: tezos-node
@@ -88,8 +115,10 @@ spec:
           mountPath: /var/tezos
       volumes:
       - name: config-volume
+        emptyDir: {}
+      - name: tqtezos-utils
         configMap:
-          name: tezos-config
+          name: tqtezos-utils
       - name: var-volume
         persistentVolumeClaim:
           claimName: tezos-pv-claim

--- a/tqchain/utils/generateTezosConfig.py
+++ b/tqchain/utils/generateTezosConfig.py
@@ -37,7 +37,7 @@ def main():
 
 def get_bootstrap_account_pubkeys():
     with open("/var/tezos/client/public_keys", "r") as f:
-        tezos_pubkey_list = json.loads(f.read())
+        tezos_pubkey_list = json.load(f)
     pubkeys = {}
     for key in tezos_pubkey_list:
         pubkeys[key["name"]] = key["value"]["key"]

--- a/tqchain/utils/generateTezosConfig.py
+++ b/tqchain/utils/generateTezosConfig.py
@@ -1,0 +1,200 @@
+#!/bin/python
+import argparse
+import json
+import os
+
+CHAIN_PARAMS = json.loads(os.environ['CHAIN_PARAMS'])
+
+def main():
+    print("Starting tezos config file generation")
+    bootstrap_accounts = get_bootstrap_account_pubkeys()
+    parameters_json = json.dumps(
+        get_parameters_config(
+            [*bootstrap_accounts.values()],
+            CHAIN_PARAMS['bootstrap_mutez'],
+        ),
+        indent = 2
+    )
+    print("Generated parameters.json :")
+    print(parameters_json)
+    with open("/etc/tezos/parameters.json", "w") as json_file:
+        print(parameters_json, file=json_file)
+
+    config_json = json.dumps(
+        get_node_config(
+            CHAIN_PARAMS['chain_name'],
+            bootstrap_accounts['genesis'],
+            CHAIN_PARAMS['timestamp'],
+            CHAIN_PARAMS['bootstrap_peers'],
+            CHAIN_PARAMS['genesis_block'],
+        ),
+        indent = 2
+    )
+    print("Generated config.json :")
+    print(config_json)
+    with open("/etc/tezos/config.json", "w") as json_file:
+        print(config_json, file=json_file)
+
+def get_bootstrap_account_pubkeys():
+    with open("/var/tezos/client/public_keys", "r") as f:
+        tezos_pubkey_list = json.loads(f.read())
+    pubkeys = {}
+    for key in tezos_pubkey_list:
+        pubkeys[key["name"]] = key["value"]["key"]
+    return pubkeys
+
+def get_node_config(
+    chain_name, genesis_key, timestamp, bootstrap_peers, genesis_block=None
+):
+
+    p2p = ["p2p"]
+    for bootstrap_peer in bootstrap_peers:
+        p2p.extend(["--bootstrap-peers", bootstrap_peer])
+
+    node_config_args = p2p + [
+        "global",
+        "rpc",
+        "network",
+        "--chain-name",
+        chain_name,
+        "genesis",
+        "--timestamp",
+        timestamp,
+        "--block",
+        genesis_block,
+        "genesis_parameters",
+        "--genesis-pubkey",
+        genesis_key,
+    ]
+
+    return generate_node_config(node_config_args)
+
+# FIXME - this should probably be replaced with subprocess calls to tezos-node-config
+def generate_node_config(node_argv):
+    parser = argparse.ArgumentParser(prog="nodeconfig")
+    subparsers = parser.add_subparsers(help="sub-command help", dest="subparser_name")
+
+    global_parser = subparsers.add_parser("global")
+    global_parser.add_argument("--data-dir", default="/var/tezos/node")
+
+    rpc_parser = subparsers.add_parser("rpc")
+    rpc_parser.add_argument("--listen-addrs", action="append", default=["0.0.0.0:8732"])
+
+    p2p_parser = subparsers.add_parser("p2p")
+    p2p_parser.add_argument("--bootstrap-peers", action="append", default=[])
+    p2p_parser.add_argument("--listen-addr", default="[::]:9732")
+    p2p_parser.add_argument("--expected-proof-of-work", default=0, type=int)
+
+    network_parser = subparsers.add_parser("network")
+    network_parser.add_argument("--chain-name")
+    network_parser.add_argument("--sandboxed-chain-name", default="SANDBOXED_TEZOS")
+    network_parser.add_argument(
+        "--default-bootstrap-peers", action="append", default=[]
+    )
+
+    genesis_parser = subparsers.add_parser("genesis")
+    genesis_parser.add_argument("--timestamp")
+    genesis_parser.add_argument(
+        "--block", default="BLockGenesisGenesisGenesisGenesisGenesisd6f5afWyME7"
+    )
+    genesis_parser.add_argument(
+        "--protocol", default="PtYuensgYBb3G3x1hLLbCmcav8ue8Kyd2khADcL5LsT5R1hcXex"
+    )
+
+    genesis_parameters_parser = subparsers.add_parser("genesis_parameters")
+    genesis_parameters_parser.add_argument("--genesis-pubkey")
+
+    namespaces = []
+    while node_argv:
+        namespace, node_argv = parser.parse_known_args(node_argv)
+        namespaces.append(namespace)
+        if not namespace.subparser_name:
+            break
+
+    node_config = {}
+    special_keys = [
+        "listen_addrs",
+        "bootstrap_peers",
+        "data_dir",
+        "listen_addr",
+        "expected_proof_of_work",
+    ]
+    for namespace in namespaces:
+        section = vars(namespace)
+        fixed_section = {}
+        for k, v in section.items():
+            if k in special_keys:
+                fixed_section[k.replace("_", "-")] = v
+            else:
+                fixed_section[k] = v
+
+        key = fixed_section.pop("subparser_name")
+        if key == "global":
+            node_config.update(fixed_section)
+        else:
+            # doubly nested parsers are a bit tricky. we'll just force the network keys where they belong
+            if key == "genesis":
+                node_config["network"][key] = fixed_section
+            elif key == "genesis_parameters":
+                node_config["network"][key] = {"values": fixed_section}
+            else:
+                node_config[key] = fixed_section
+
+    return node_config
+
+
+def get_parameters_config(bootstrap_accounts, bootstrap_mutez):
+    parameter_config_argv = []
+    for bootstrap_account in bootstrap_accounts:
+            parameter_config_argv.extend(
+                [
+                    "--bootstrap-accounts",
+                    bootstrap_account,
+                    bootstrap_mutez,
+                ]
+            )
+    return generate_parameters_config(parameter_config_argv)
+
+
+def generate_parameters_config(parameters_argv):
+    parser = argparse.ArgumentParser(prog="parametersconfig")
+    parser.add_argument(
+        "--bootstrap-accounts",
+        type=str,
+        nargs="+",
+        action="append",
+        help="public key, mutez",
+    )
+    parser.add_argument("--preserved-cycles", type=int, default=2)
+    parser.add_argument("--blocks-per-cycle", type=int, default=8)
+    parser.add_argument("--blocks-per-commitment", type=int, default=4)
+    parser.add_argument("--blocks-per-roll-snapshot", type=int, default=4)
+    parser.add_argument("--blocks-per-voting-period", type=int, default=64)
+    parser.add_argument("--time-between-blocks", default=["10", "20"])
+    parser.add_argument("--endorsers-per-block", type=int, default=32)
+    parser.add_argument("--hard-gas-limit-per-operation", default="800000")
+    parser.add_argument("--hard-gas-limit-per-block", default="8000000")
+    parser.add_argument("--proof-of-work-threshold", default="-1")
+    parser.add_argument("--tokens-per-roll", default="8000000000")
+    parser.add_argument("--michelson-maximum-type-size", type=int, default=1000)
+    parser.add_argument("--seed-nonce-revelation-tip", default="125000")
+    parser.add_argument("--origination-size", type=int, default=257)
+    parser.add_argument("--block-security-deposit", default="512000000")
+    parser.add_argument("--endorsement-security-deposit", default="64000000")
+    parser.add_argument("--endorsement-reward", default=["2000000"])
+    parser.add_argument("--cost-per-byte", default="1000")
+    parser.add_argument("--hard-storage-limit-per-operation", default="60000")
+    parser.add_argument("--test-chain-duration", default="1966080")
+    parser.add_argument("--quorum-min", type=int, default=2000)
+    parser.add_argument("--quorum-max", type=int, default=7000)
+    parser.add_argument("--min-proposal-quorum", type=int, default=500)
+    parser.add_argument("--initial-endorsers", type=int, default=1)
+    parser.add_argument("--delay-per-missing-endorsement", default="1")
+    parser.add_argument("--baking-reward-per-endorsement", default=["200000"])
+
+    namespace = parser.parse_args(parameters_argv)
+    return vars(namespace)
+
+
+if __name__ == "__main__":
+    main()

--- a/tqchain/utils/import_keys.sh
+++ b/tqchain/utils/import_keys.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+mkdir -p /var/tezos/client
+chmod -R 777 /var/tezos/client
+
+for acct in ${BOOTSTRAP_ACCOUNTS}; do
+    key=$(eval echo \$${acct}_${KEYS_TYPE}_key)
+    tezos-client -d /var/tezos/client --protocol PsCARTHAGazK import ${KEYS_TYPE} key $acct unencrypted:${key} -f
+done


### PR DESCRIPTION
Removes the requirement of having NFS-mounted /var/tezos dir.

When creating a new chain, there is one extra command to generate
constants: bootstrap account keys, chain id and timestamp.

The command is

  mkchain --generate-constants <CHAIN_NAME>

It generates 2 files: <CHAIN_NAME>_chain.yaml and
<CHAIN_NAME>_chain_invite.yaml

Then everything works as expected.

2 new init containers have been introduced:

* import-keys: injects the keys in the node (private keys for bootstrap
node, public keys for invited nodes)

* generate-tezos-config creates config.json and parameters.json from
the given constants (this code was previously in mkchain)

This is an intermediary step towards making the chain creation process
declarative: give your constants as input, get a working k8s spec as
output, for both bootstrap nodes and invited nodes.

For now:

The --generate-constants uses local docker containers (tezos and flextesa)
to generate constants.

The --create step is self-contained and just doing templating.

The --invite step queries the bootstrap cluster for the nodeport and
requires the ip of the bootstrap node to be passed manually, but it
no longer downloads its (config|parameter).json files from the cluster,
instead generating them using the same mechanism that the bootstrap node.

Other changes:

* open up the RPC port of the nodes