### PR TITLE
Setup github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,108 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  release:
+    types: [created]
+
+jobs:
+  check-lint-and-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install black isort autoflake
+
+      - name: Remove unused imports
+        run: |
+          # one run to output unused imports, another run for exit code
+          autoflake . -r --remove-all-unused-imports
+          autoflake . -r --remove-all-unused-imports -c
+
+      - name: Sort imports
+        run: isort . --check --diff -rc
+
+      - name: black
+        run: black . --check
+
+  test:
+    runs-on: ${{ matrix.os }}
+    needs: check-lint-and-format
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyyaml kubernetes
+          pip install pytest
+
+      - name: Build Python package
+        run: pip install .
+
+      - name: pytest
+        run: pytest tests
+
+  publish:
+    needs: test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      # after we test that the module works on all systems we only need to build one since this is a pure python module
+      matrix:
+        python-version: [3.8]
+        os: [ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyyaml kubernetes
+          pip install wheel
+
+      - name: Build Python package
+        run: python setup.py bdist_wheel
+
+      - name: Install wheels
+        run: pip install dist/*.whl
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: dist/*.whl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish package to TestPYPI
+        if: github.event_name == 'release' && github.event.action == 'created'
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 *.pyc
 *.egg-info
 .venv*
+build

--- a/lint.sh
+++ b/lint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+autoflake . -r --remove-all-unused-imports -i
+isort . -rc
+black .

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,26 @@
-from distutils.core import setup
+import setuptools
 
-setup(
+with open("README.md", "r") as readme:
+    long_description = readme.read()
+
+setuptools.setup(
     name="mkchain",
     version="0.1",
     packages=["tqchain"],
+    author="TQ Tezos",
+    description="A utility to generate k8s configs for a Tezos blockchain",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/tqtezos/tezos-k8s",
     include_package_data=True,
     install_requires=["pyyaml", "kubernetes"],
+    setup_requires=["wheel"],
+    extras_require={"dev": ["pytest", "autoflake", "isort", "black"]},
     entry_points={"console_scripts": ["mkchain=tqchain.mkchain:main"]},
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    python_requires=">=3.6",
 )

--- a/tests/test_package_exists.py
+++ b/tests/test_package_exists.py
@@ -1,0 +1,4 @@
+def test_package_exists() -> None:
+    import tqchain
+
+    assert vars(tqchain)["__name__"] == "tqchain"

--- a/tqchain/mkchain.py
+++ b/tqchain/mkchain.py
@@ -2,15 +2,12 @@ import argparse
 import base64
 import json
 import os
-import platform
 import random
 import string
 import subprocess
 import sys
 import uuid
-from datetime import datetime
-from datetime import timezone
-from ipaddress import IPv4Address
+from datetime import datetime, timezone
 
 import yaml
 from kubernetes import client as k8s_client


### PR DESCRIPTION
This PR sets up some automated CI that does the following:

- Rejects all PRs / fails builds for commits that aren't formatted w/ black + don't have sorted and cleaned imports
- Runs tests (I put in a placeholder test - what matters for the sake of this PR is that the test infrastructure is there) and rejects PRs with failed tests
- Automatically pushes to TestPYPI upon creation of a release. We can change this to real pypi when we have a token to use - for now, I can supply a TestPYPI token. This job will need a PYPI_TOKEN secret, which I do not have permission to put in this repo. But we don't need the token yet if we're not tagging any releases.

I also include `./lint.sh`, which should automatically lint all python code in the repo to ensure that the lint job won't fail.