### PR TITLE
Add matching label to all tezos nodes

### DIFF
--- a/MULTICLUSTER.md
+++ b/MULTICLUSTER.md
@@ -173,5 +173,5 @@ chain.
 Check that the nodes have matching heads by comparing their hashes:
 
 ``` shell
-kubectl -n tqtezos exec deployment/tezos-node -c tezos-node -- /usr/local/bin/tezos-client rpc get /chains/main/blocks/head/hash
+kubectl get pod -n tqtezos -l appType=tezos -o name | while read line; do kubectl -n tqtezos exec $line -c tezos-node -- /usr/local/bin/tezos-client rpc get /chains/main/blocks/head/hash; done
 ```

--- a/tqchain/deployment/bootstrap-node.yaml
+++ b/tqchain/deployment/bootstrap-node.yaml
@@ -106,6 +106,7 @@ spec:
     metadata:
       labels:
         app: tezos-bootstrap-node
+        appType: tezos
     spec:
       securityContext:
         fsGroup: 100

--- a/tqchain/deployment/node.yaml
+++ b/tqchain/deployment/node.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: tezos-node
+        appType: tezos
     spec:
       securityContext:
         fsGroup: 100


### PR DESCRIPTION
This PR adds a label to each tezos-node manifest so that we can have a matching command for both chain creators and invitees to view block heads. In addition, this lets the creator to view the heads of all the replicas along w/ their progenitor node at the same time with a single command; see the change in MULTICLUSTER.md