### PR TITLE
Only import the required keys in init containers

### DIFF
--- a/charts/tezos/templates/baker.yaml
+++ b/charts/tezos/templates/baker.yaml
@@ -200,7 +200,6 @@ spec:
           name: config-generator
           args:
             - "--generate-config-json"
-            - "--generate-parameters-json"
           envFrom:
             - configMapRef:
                 name: tezos-config

--- a/key-importer/entrypoint.sh
+++ b/key-importer/entrypoint.sh
@@ -1,12 +1,52 @@
 #!/bin/sh
+
 mkdir -p /var/tezos/client
 chmod -R 777 /var/tezos/client
 
-echo $ACCOUNTS | jq -c --raw-output .[] | while read line; do
-    key=$(echo $line | jq -r '.key')
-    name=$(echo $line | jq -r '.name')
-    keytype=$(echo $line | jq -r '.type')
-    protocol=$(echo $CHAIN_PARAMS | jq -r '.protocol_hash')
-    printf "\nImporting key ${name}\n"
-    tezos-client -d /var/tezos/client --protocol ${protocol} import ${keytype} key ${name} unencrypted:${key} -f
-done
+PROTOCOL=$(echo $CHAIN_PARAMS | jq -r '.protocol_hash')
+
+import_single_key() {
+    read keytype
+    read name
+    read key
+
+echo tezos-client -d /var/tezos/client --protocol $PROTOCOL \
+	import ${keytype} key ${name} unencrypted:${key} -f
+
+    tezos-client -d /var/tezos/client --protocol $PROTOCOL \
+	import ${keytype} key ${name} unencrypted:${key} -f
+    echo "Imported keytype $keytype name $name"
+}
+
+import_all_keys() {
+    echo $ACCOUNTS | jq -c --raw-output .[] | while read LINE; do
+	echo $LINE | jq -r '.type, .name, .key' | import_single_key
+    done
+}
+
+import_key() {
+    echo $ACCOUNTS | \
+    jq -r ".[] | select(.name == \"baker$1\") | .type, .name, .key" | 
+	import_single_key
+}
+
+HOSTNAME=$(hostname)
+MY_NODE=${HOSTNAME##tezos-baking-node-}
+
+#
+# The activation job needs all of the keys:
+
+if [ "${HOSTNAME#activate-job}" != ${HOSTNAME} ]; then
+    import_all_keys
+    exit 0
+fi
+
+#
+# For some reason, we all need to have baker0's key.  We can likely
+# fix this in the future, I would imagine.
+
+import_key 0
+
+if [ "$MY_NODE" != "$HOSTNAME" -a "$MY_NODE" != 0 ]; then
+    import_key $MY_NODE
+fi


### PR DESCRIPTION
We can improve this further in time for large scale nodes, specifically, maybe we can just create one bootstrap account on a single node and have bakers create their own accounts as they spawn and then drink from a faucet. This would scale much better as we wouldn't have to create all of the accounts serially in advance but would rather create them in parallel at spawn time.