### PR TITLE
Remove readiness probes

### DIFF
--- a/charts/tezos/templates/baker.yaml
+++ b/charts/tezos/templates/baker.yaml
@@ -97,16 +97,6 @@ spec:
               name: tezos-rpc
             - containerPort: 9732
               name: tezos-net
-          readinessProbe:
-            exec:
-              command:
-                - nc
-                - "-z"
-                - '127.0.0.1'
-                - '8732'
-            initialDelaySeconds: 2
-            periodSeconds: 2
-            timeoutSeconds: 1
           volumeMounts:
             - mountPath: /etc/tezos
               name: config-volume

--- a/charts/tezos/templates/node.yaml
+++ b/charts/tezos/templates/node.yaml
@@ -31,16 +31,6 @@ spec:
               name: tezos-rpc
             - containerPort: 9732
               name: tezos-p2p
-          readinessProbe:
-            exec:
-              command:
-                - nc
-                - "-z"
-                - '127.0.0.1'
-                - '8732'
-            initialDelaySeconds: 2
-            periodSeconds: 2
-            timeoutSeconds: 1
           volumeMounts:
             - mountPath: /etc/tezos
               name: config-volume


### PR DESCRIPTION
Readiness probes have the unfortunate side-effect of causing the
DNS resolution of our hostnames to fail whenever kubernetes thinks
that the node is not ready.  This exposes some underlying bugs in
tezos-node and causes many nodes to simply stop trying to find
peers.  Waiting to start helps the issue, but we find that minikubes
sometimes decides that nodes are unavailable randomly even after it
considered them to be ready.  This makes our name service complete
non-deterministic.