### PR TITLE
Decouple number-of-nodes from number-of-bakers

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,17 +171,16 @@ chain running one node.
 
 ## Adding nodes within the cluster
 
-You can configure a self-contained testnet within your cluster with
-a number of nodes of your choice by passing `--number-of-nodes N` to `mkchain`. Pass this along with your previously used flags (`--zerotier-network` and `--zerotier-token`). You can use this to scale up and down.
+You can configure the number of nodes in your cluster by passing `--number-of-nodes N` to `mkchain`. Pass this along with your previously used flags (`--zerotier-network` and `--zerotier-token`). You can use this to scale up and down.
 
-Or if you previously spun up the chain using `mkchain`, you may scale up/down your setup to an arbitrary number of nodes by adding or removing nodes in the `nodes` list in the values yaml file:
+Or if you previously spun up the chain using `mkchain`, you may scale up/down your setup to an arbitrary number of nodes by adding or removing nodes in the `nodes.regular` list in the values yaml file:
 
 ```yaml
 # <CURRENT WORKING DIRECTORY>/${CHAIN_NAME}_values.yaml
 nodes:
-  - bake_for: baker
+  regular:
+  - {} # first non-baking node
   - {} # second non-baking node
-  - {} # third non-baking node
 ```
 
 To upgrade your Helm release run:

--- a/mkchain/README.md
+++ b/mkchain/README.md
@@ -57,8 +57,8 @@ You can explicitly specify some values by:
 | -------------------------------- | ------------------ | --------------------------------------------------------------------------- | ---------------------- |
 | bootstrap_peer                   | --bootstrap-peer   | Peer ip to connect to                                                       |                        |
 | images.tezos                     | --docker-image     | Version of the Tezos docker image                                           | tezos/tezos:v8-release |
-| number_of_nodes                  | --number-of-nodes  | Number number of plain nodes in the cluster                                 | 1                      |
-| number_of_bakers                 | --number-of-bakers | Number of nodes in the cluster that are bakers                              | 1                      |
+| number_of_nodes                  | --number-of-nodes  | Number of non-baking nodes in the cluster                                   | 1                      |
+| number_of_bakers                 | --number-of-bakers | Number of baking nodes in the cluster                                       | 1                      |
 | rpc_auth                         | --rpc-auth         | Whether or not an [RPC auth](../rpc-auth/README.md) backend will be spun up | False                  |
 | zerotier_config.zerotier_network | --zerotier-network | Zerotier network id for external chain access                               |                        |
 | zerotier_config.zerotier_token   | --zerotier-token   | Zerotier token for external chain access                                    |                        |

--- a/mkchain/README.md
+++ b/mkchain/README.md
@@ -57,7 +57,7 @@ You can explicitly specify some values by:
 | -------------------------------- | ------------------ | --------------------------------------------------------------------------- | ---------------------- |
 | bootstrap_peer                   | --bootstrap-peer   | Peer ip to connect to                                                       |                        |
 | images.tezos                     | --docker-image     | Version of the Tezos docker image                                           | tezos/tezos:v8-release |
-| number_of_nodes                  | --number-of-nodes  | Total number of nodes in the cluster                                        | 1                      |
+| number_of_nodes                  | --number-of-nodes  | Number number of plain nodes in the cluster                                 | 1                      |
 | number_of_bakers                 | --number-of-bakers | Number of nodes in the cluster that are bakers                              | 1                      |
 | rpc_auth                         | --rpc-auth         | Whether or not an [RPC auth](../rpc-auth/README.md) backend will be spun up | False                  |
 | zerotier_config.zerotier_network | --zerotier-network | Zerotier network id for external chain access                               |                        |

--- a/mkchain/tqchain/mkchain.py
+++ b/mkchain/tqchain/mkchain.py
@@ -195,7 +195,7 @@ def main():
 
     creation_nodes = {
         "baking": [{"bake_for": f"baker{n}"} for n in range(args.number_of_bakers)],
-        "regular": [{} for n in range(args.number_of_nodes - args.number_of_bakers)],
+        "regular": [{} for n in range(args.number_of_nodes)],
     }
 
     # first nodes are acting as bootstrap nodes for the others

--- a/mkchain/tqchain/mkchain.py
+++ b/mkchain/tqchain/mkchain.py
@@ -120,15 +120,25 @@ def pull_docker_images(images):
 def main():
     args = get_args()
 
-    if args.number_of_nodes < 1:
+    if args.number_of_nodes < 0:
         print(
-            f"Invalid argument --number-of-nodes {args.number_of_nodes}, must be 1 or more"
+            f"Invalid argument --number-of-nodes ({args.number_of_nodes}) "
+            f"must be non-negative"
         )
         exit(1)
 
-    if args.number_of_bakers < 1:
+    if args.number_of_bakers < 0:
         print(
-            f"Invalid argument --number-of-bakers {args.number_of_bakers}, must be 1 or more"
+            f"Invalid argument --number-of-bakers ({args.number_of_bakers}) "
+            f"must be non-negative"
+        )
+        exit(1)
+
+    if args.number_of_nodes + args.number_of_bakers < 1:
+        print(
+            f"Invalid arguments: either "
+            f"--number-of-nodes ({args.number_of_nodes}) or "
+            f"--number-of-bakers ({args.number_of_bakers}) must be non-zero"
         )
         exit(1)
 


### PR DESCRIPTION
We now consider --number-of-nodes to be the nodes which do not
include a baker/endorser pair.  It's more natural to consider
that:

    $ mkchain --number-of-bakers 40 --number-of-nodes 5 my_chain

will bring up 40 baker nodes and 5 plain nodes.

This is helpful with pulumi because it has been waiting for zero nodes
to come up and timing out.  With the current code:

    $ mkchain --number-of-bakers 40 my_chain

will bring up 40 bakers and a single node.