### PR TITLE
Remove docker as a dependency of mkchain

### DIFF
--- a/charts/tezos/templates/configs.yaml
+++ b/charts/tezos/templates/configs.yaml
@@ -7,7 +7,7 @@ data:
       "nodes": {{ toJson .Values.nodes }},
       "chain_name": "{{ .Values.chain_name }}",
       "genesis_block": "{{ .Values.genesis.block }}",
-      "activation_account": "{{ (index .Values.accounts 0).name }}",
+      "activation_account": "{{ default "baker0" (first .Values.accounts).name }}",
       "timestamp": "{{ .Values.genesis.timestamp }}",
       "zerotier_in_use": {{ .Values.zerotier_in_use }},
       "proto_command": "{{ .Values.protocol.command }}",


### PR DESCRIPTION
closes #89
closes #26 
Both of these closes were enabled by PR #105

Issue #46 has relation to this PR. Perhaps it should be closed and a new ticket opened regarding funneling generated constants inside k8s, outside to host land.