### PR TITLE
fix zerotier invite for f-beta

### DIFF
--- a/mkchain/tqchain/mkchain.py
+++ b/mkchain/tqchain/mkchain.py
@@ -230,7 +230,10 @@ def main():
     if len(creation_nodes["baking"]) > 1:
         creation_nodes["baking"][1]["bootstrap"] = True
 
-    invitation_nodes = {"baking": [], "regular": [{}]}
+    invitation_nodes = {
+        "baking": [],
+        "regular": [{"name": f"tezos-node-{n}"} for n in range(args.number_of_nodes)],
+    }
 
     bootstrap_peers = [args.bootstrap_peer] if args.bootstrap_peer else []
 


### PR DESCRIPTION
invite is broken when invitation yaml is created by mkchain since it is not including a name for the invited node. Name is mandatory now in `f-beta`. This was previously fixed for `*_values.yaml` but not for `*_invite_values.yaml`