### PR TITLE
Deprecated argument in mkchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ The `--chain-type` parameter lets you choose between these different types.
 Run the following commands to create the Helm values, get the Helm chart repo, and install the Helm chart to start your chain.
 
 ```shell
-mkchain $CHAIN_NAME --zerotier-network $ZT_NET --zerotier-token $ZT_TOKEN --chain-type private
+mkchain $CHAIN_NAME --zerotier-network $ZT_NET --zerotier-token $ZT_TOKEN
 
 helm repo add tqtezos https://tqtezos.github.io/tezos-helm-charts
 


### PR DESCRIPTION
Removed `--chain-type` in the `README`.

```
$ mkchain $CHAIN_NAME --zerotier-network $ZT_NET --zerotier-token $ZT_TOKEN --chain-type private
usage: mkchain [-h] [--version] [--number-of-nodes NUMBER_OF_NODES] [--number-of-bakers NUMBER_OF_BAKERS] [--zerotier-network ZEROTIER_NETWORK]
               [--zerotier-token ZEROTIER_TOKEN] [--bootstrap-peer BOOTSTRAP_PEER] [--docker-image DOCKER_IMAGE] [--rpc-auth]
               chain_name
mkchain: error: unrecognized arguments: --chain-type private
```