### PR TITLE
pulumi/index.ts: use the stack name rather than an env var...

### DIFF
--- a/pulumi/index.ts
+++ b/pulumi/index.ts
@@ -13,7 +13,7 @@ const repo = new awsx.ecr.Repository("tezos-k8s");
 //   mkchain pulumi
 //
 
-const chainName = process.env.CHAIN_NAME || "pulumi";
+const chainName = pulumi.getStack();
 
 const defaultHelmValuesFile = fs.readFileSync("../charts/tezos/values.yaml", 'utf8')
 const defaultHelmValues = YAML.parse(defaultHelmValuesFile)


### PR DESCRIPTION
...to find the _values.yaml file.  This makes it easier to swap
back and forth between different chains in the same directory as
you can just:

   $ pulumi stack select <new-stack>

And not have to worry about forgetting to change an env var as
well.