### PR TITLE
wait-for-bootstrap: wait for a configured node

### DIFF
--- a/charts/tezos/templates/baker.yaml
+++ b/charts/tezos/templates/baker.yaml
@@ -163,6 +163,9 @@ spec:
         - image: {{ .Values.tezos_k8s_images.wait_for_bootstrap }}
           imagePullPolicy: IfNotPresent
           name: wait-for-bootstrap
+          envFrom:
+            - configMapRef:
+                name: tezos-config
           volumeMounts:
             - mountPath: /var/tezos
               name: var-volume

--- a/charts/tezos/templates/node.yaml
+++ b/charts/tezos/templates/node.yaml
@@ -68,6 +68,9 @@ spec:
         - image: {{ .Values.tezos_k8s_images.wait_for_bootstrap }}
           imagePullPolicy: IfNotPresent
           name: wait-for-bootstrap
+          envFrom:
+            - configMapRef:
+                name: tezos-config
           volumeMounts:
             - mountPath: /var/tezos
               name: var-volume


### PR DESCRIPTION
Previously, we unconditionally waited for tezos-baking-node-0.  Now,
we take the configured list of nodes and wait until at least one of
them is up and running.

Also hit #161 as a drive-by.