### PR TITLE
Fix vms per node

### DIFF
--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -143,6 +143,12 @@ protocol:
   # tezos/tezos:v8-release docker image.
   command: 008-PtEdo2Zk
 
+#
+# Pulumi values:
+
+pulumi:
+  vms_per_node: 12
+
 # # Activate a new chain from genesis. Note, this is only for when your chain does
 # # not exist yet. For subsequent deploys, remove this.
 #

--- a/pulumi/index.ts
+++ b/pulumi/index.ts
@@ -40,8 +40,8 @@ const vpc = new awsx.ec2.Vpc(chainName + "-vpc", {});
 // we should experiment a little to get a better number.  We add
 // three because that's the minimum.
 
-const numBakers = helmValues.nodes?.baking?.length || 0
-const numRegularNodes  = helmValues.nodes?.regular?.length || 0
+const numBakers       = Object.keys(helmValues.nodes?.baking  || {}).length
+const numRegularNodes = Object.keys(helmValues.nodes?.regular || {}).length
 
 const totalTezosNodes = numBakers + numRegularNodes
 const desiredClusterCapacity = Math.round(totalTezosNodes / 12 + 3);


### PR DESCRIPTION
When we changed the format for representing nodes from a list to an object, my pulumi code to count them and scale the network appropriately broke.