### PR TITLE
Make tezos node's sts's and svc's conditional

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Running either of these commands results in:
 You can find your node in the tqtezos namespace with some status information using `kubectl`.
 
 ```shell
-kubectl -n tqtezos get pods -l appType=tezos
+kubectl -n tqtezos get pods -l appType=tezos-node
 ```
 
 You can monitor (and follow using the `-f` flag) the logs of the snapshot downloader/import container:
@@ -172,7 +172,7 @@ kubectl logs -n tqtezos statefulset/tezos-node -c snapshot-downloader -f
 You can view logs for your node using the following command:
 
 ```shell
-kubectl -n tqtezos logs -l appType=tezos -c tezos-node -f --prefix
+kubectl -n tqtezos logs -l appType=tezos-node -c tezos-node -f --prefix
 ```
 
 IMPORTANT:
@@ -281,13 +281,13 @@ perform the following tasks:
 You can find your node in the tqtezos namespace with some status information using kubectl.
 
 ```shell
-kubectl -n tqtezos get pods -l appType=tezos
+kubectl -n tqtezos get pods -l appType=tezos-node
 ```
 
 You can view (and follow using the `-f` flag) logs for your node using the following command:
 
 ```shell
-kubectl -n tqtezos logs -l appType=tezos -c tezos-node -f --prefix
+kubectl -n tqtezos logs -l appType=tezos-node -c tezos-node -f --prefix
 ```
 
 Congratulations! You now have an operational Tezos based permissioned
@@ -325,7 +325,7 @@ helm upgrade $CHAIN_NAME tqtezos/tezos-chain \
 
 The nodes will start up and establish peer-to-peer connections in a full mesh topology.
 
-List all of your running nodes: `kubectl -n tqtezos get pods -l appType=tezos`
+List all of your running nodes: `kubectl -n tqtezos get pods -l appType=tezos-node`
 
 ## Adding external nodes to the cluster
 
@@ -361,7 +361,7 @@ Congratulations! You now have a multi-node Tezos based permissioned chain.
 On each computer, run this command to check that the nodes have matching heads by comparing their hashes (it may take a minute for the nodes to sync up):
 
 ```shell
-kubectl get pod -n tqtezos -l appType=tezos -o name |
+kubectl get pod -n tqtezos -l appType=tezos-node -o name |
 while read line;
   do kubectl -n tqtezos exec $line -c tezos-node -- /usr/local/bin/tezos-client rpc get /chains/main/blocks/head/hash;
 done

--- a/charts/tezos/templates/_helpers.tpl
+++ b/charts/tezos/templates/_helpers.tpl
@@ -27,6 +27,34 @@
 {{- end }}
 
 {{/*
+  Don't deploy the baker statefulset and its headless service if
+  there are no bakers specified.
+  Returns a string "true" or empty string which is falsey.
+*/}}
+{{- define "tezos.shouldDeployBakerStatefulset" -}}
+{{- $baking_nodes := .Values.nodes.baking | default dict }}
+{{- if and (not .Values.is_invitation) ($baking_nodes | len) }}
+{{- "true" }}
+{{- else }}
+{{- "" }}
+{{- end }}
+{{- end }}
+
+{{/*
+  Don't deploy the regular node statefulset and its headless service if
+  there are no regular nodes specified.
+  Returns a string "true" or empty string which is falsey.
+*/}}
+{{- define "tezos.shouldDeployRegularNodeStatefulset" -}}
+{{- $regular_nodes := .Values.nodes.regular | default dict }}
+{{- if ($regular_nodes | len) }}
+{{- "true" }}
+{{- else }}
+{{- "" }}
+{{- end }}
+{{- end }}
+
+{{/*
   Checks if a protocol should be activated. There needs to be a protocol_hash
   and protocol_parameters.
   Returns a string "true" or empty string which is falsey.

--- a/charts/tezos/templates/baker.yaml
+++ b/charts/tezos/templates/baker.yaml
@@ -74,7 +74,7 @@ spec:
     metadata:
       labels:
         app: {{ .Values.baker_statefulset.name }}
-        appType: tezos
+        appType: tezos-node
     spec:
       containers:
 {{- include "tezos.container.node"     . | indent 8 }}

--- a/charts/tezos/templates/baker.yaml
+++ b/charts/tezos/templates/baker.yaml
@@ -57,7 +57,7 @@ spec:
           name: var-volume
 {{ end }}
 ---
-{{- if not .Values.is_invitation }}
+{{- if (include "tezos.shouldDeployBakerStatefulset" .) }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/charts/tezos/templates/node.yaml
+++ b/charts/tezos/templates/node.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         app: {{ .Values.regular_node_statefulset.name }}
-        appType: tezos
+        appType: tezos-node
     spec:
       containers:
 {{- include "tezos.container.node"     . | indent 8 }}

--- a/charts/tezos/templates/node.yaml
+++ b/charts/tezos/templates/node.yaml
@@ -1,3 +1,4 @@
+{{- if (include "tezos.shouldDeployRegularNodeStatefulset" .) }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -43,3 +44,4 @@ spec:
         resources:
           requests:
             storage: {{ .Values.regular_node_statefulset.storage_size }}
+{{- end }}

--- a/charts/tezos/templates/static.yaml
+++ b/charts/tezos/templates/static.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   ports:
     - port: 8732
+      name: rpc
   selector:
     app: tezos-baking-node
   type: NodePort

--- a/charts/tezos/templates/static.yaml
+++ b/charts/tezos/templates/static.yaml
@@ -8,7 +8,7 @@ spec:
     - port: 8732
       name: rpc
   selector:
-    app: tezos-baking-node
+    appType: tezos-node
   type: NodePort
 ---
 {{- if (include "tezos.shouldDeployRegularNodeStatefulset" .) }}

--- a/charts/tezos/templates/static.yaml
+++ b/charts/tezos/templates/static.yaml
@@ -10,6 +10,7 @@ spec:
     app: tezos-baking-node
   type: NodePort
 ---
+{{- if (include "tezos.shouldDeployRegularNodeStatefulset" .) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -18,6 +19,9 @@ spec:
   clusterIP: None
   selector:
     app: {{ .Values.regular_node_statefulset.name }}
+{{- end }}
+
+{{- if (include "tezos.shouldDeployBakerStatefulset" .) }}
 ---
 apiVersion: v1
 kind: Service
@@ -27,3 +31,4 @@ spec:
   clusterIP: None
   selector:
     app: {{ .Values.baker_statefulset.name }}
+{{- end }}


### PR DESCRIPTION
This became necessary due to pulumi erroring out if the svc for the sts's existed without any sts replicas.
Also rpc svc can select bakers and regular nodes.