### PR TITLE
User activated upgrade support

### DIFF
--- a/charts/tezos/scripts/README
+++ b/charts/tezos/scripts/README
@@ -18,7 +18,7 @@ TEMPLATING
     Because the templating system is used, you can use any of the
     features provided.  Mostly, variable expansion, i.e.
 
-	{{ .Values.protocol.command }}
+	{{ .Values.expected_proof_of_work }}
 
     If you use braces within the file, you will have to escape them,
     though:

--- a/charts/tezos/scripts/baker-endorser.sh
+++ b/charts/tezos/scripts/baker-endorser.sh
@@ -6,7 +6,7 @@ CLIENT_DIR="$TEZ_VAR/client"
 NODE_DIR="$TEZ_VAR/node"
 NODE_DATA_DIR="$TEZ_VAR/node/data"
 
-proto_command="{{ .Values.protocol.command }}"
+proto_command="{{ .command_in_tpl }}"
 
 if [ "${DAEMON}" == "baker" ]; then
     extra_args="with local node $NODE_DATA_DIR"

--- a/charts/tezos/templates/_containers.tpl
+++ b/charts/tezos/templates/_containers.tpl
@@ -142,7 +142,7 @@
       name: var-volume
 {{- end }}
 
-{{- define "tezos.container.baker" }}
+{{- define "tezos.container.bakers" }}
 {{- range .Values.protocols }}
 - image: "{{ $.Values.images.tezos }}"
   command:
@@ -173,7 +173,7 @@ https://github.com/helm/helm/issues/5979#issuecomment-518231758
 {{- end }}
 {{- end }}
 
-{{- define "tezos.container.endorser" }}
+{{- define "tezos.container.endorsers" }}
 {{- range .Values.protocols }}
 - image: "{{ $.Values.images.tezos }}"
   command:

--- a/charts/tezos/templates/baker.yaml
+++ b/charts/tezos/templates/baker.yaml
@@ -77,10 +77,10 @@ spec:
         appType: tezos-node
     spec:
       containers:
-{{- include "tezos.container.node"     . | indent 8 }}
-{{- include "tezos.container.baker"    . | indent 8 }}
-{{- include "tezos.container.endorser" . | indent 8 }}
-{{- include "tezos.container.zerotier" . | indent 8 }}
+{{- include "tezos.container.node"      . | indent 8 }}
+{{- include "tezos.container.bakers"    . | indent 8 }}
+{{- include "tezos.container.endorsers" . | indent 8 }}
+{{- include "tezos.container.zerotier"  . | indent 8 }}
       initContainers:
 {{- include "tezos.init_container.config_init"         . | indent 8 }}
 {{- include "tezos.init_container.wait_for_bootstrap"  . | indent 8 }}

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -136,6 +136,8 @@ protocols:
   # List here the protocols that you wish to run bakers and endorsers for.
   # These binaries must be present in the docker image specified.
   # You may want to run two or more if you are expecting an on-chain upgrade.
+  # Be mindful that running more protocols will start more containers in your
+  # pods which may consume more memory.
   - command: 009-PsFLoren
   #- command: alpha
 

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -131,10 +131,13 @@ expected_proof_of_work: 26
 node_config_network:
   chain_name: mainnet
 
-protocol:
-  # Set the protocol binary. The protocol must be recognized by the
-  # tezos/tezos:v8-release docker image.
-  command: 008-PtEdo2Zk
+protocols:
+  # Tezos builds baker and endorser binaries for every supported protocol.
+  # List here the protocols that you wish to run bakers and endorsers for.
+  # These binaries must be present in the docker image specified.
+  # You may want to run two or more if you are expecting an on-chain upgrade.
+  - command: 009-PsFLoren
+  #- command: alpha
 
 # # Activate a new chain from genesis. Note, this is only for when your chain does
 # # not exist yet. For subsequent deploys, remove this.

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -473,15 +473,12 @@ def create_node_config_json(
                 "expected-proof-of-work"
             ]
 
-        node_config["network"] = {
-            "chain_name": NETWORK_CONFIG["chain_name"],
-            "sandboxed_chain_name": "SANDBOXED_TEZOS",
-            "default_bootstrap_peers": [],
-            "genesis": NETWORK_CONFIG["genesis"],
-            "genesis_parameters": {
-                "values": {"genesis_pubkey": get_genesis_pubkey()},
-            },
-        }
+        node_config["network"] = NETWORK_CONFIG
+        node_config["network"]["sandboxed_chain_name"] = "SANDBOXED_TEZOS"
+        node_config["network"]["default_bootstrap_peers"] = []
+        node_config["network"]["genesis_parameters"] = {
+                "values": {"genesis_pubkey": get_genesis_pubkey()} }
+        node_config["network"].pop("activation_account_name")
 
     return node_config
 


### PR DESCRIPTION
It is possible to force the tezos node to switch protocol at a given
level. This is part of the network config section.

Example:
```
   "network": {
     "chain_name": "nico",
     "genesis": {
       "block": "BMFonSBNMfDf6MFRAw25xsCKhxx6f1gUsPr6KWnNZaviKu6Ak5D",
       "protocol":
"PtYuensgYBb3G3x1hLLbCmcav8ue8Kyd2khADcL5LsT5R1hcXex",
       "timestamp": "2021-05-02T01:25:17.944261+00:00"
     },
     "user_activated_upgrades": [
       {
         "level": 5,
         "replacement_protocol":
"ProtoALphaALphaALphaALphaALphaALphaALphaALphaDdp3zK"
       }
     ],
     "sandboxed_chain_name": "SANDBOXED_TEZOS",
     "default_bootstrap_peers": [],
     "genesis_parameters": {
       "values": {
         "genesis_pubkey":
"edpkvFcxq7NYu2PCYD9pjABSZMK3ypVPnYwCPpRZCpwpsRuYvHA8ZU"
       }
     }
   }
 }
```

To make it work in tezos-k8s, the following was done:

1. support for running baker and endorser binaries for several protocols
   at once. This is done by converting the `protocol` value into
   `protocols`. This is great, since it also enables support of seamless
   transition between protocol during real mainnet upgrades.
2. replace the ad-hoc build of the network config with a pass-through of
   every key/value pair passed in values.yaml `node_config_network`
   value into the node's network config. This enables support of any
   network feature that we don't know of yet, in addition to the
   user-activated upgrade which is of interest here. [Here is an example of this feature being used in galpha2net](https://github.com/tqtezos/teztnets/pull/12/files#diff-887d7eefee11c072829a52ea5d64be0d91e6d20cbdb07553846485caa763cbc6R9-R11).

Maybe also `sandboxed_chain_name` should be brought into this
passthrough instead of being hardcoded?