### PR TITLE
preliminary work for private mode support

### DIFF
--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -1,4 +1,5 @@
 import argparse
+import collections.abc
 import json
 import os
 import socket
@@ -445,6 +446,19 @@ def get_genesis_pubkey():
             raise Exception("ERROR: Couldn't find the genesis_pubkey")
         return genesis_pubkey
 
+def recursive_update(d, u):
+    '''
+    Recursive dict update
+    Used to merge node's config passed as chart values
+    and computed values
+    https://stackoverflow.com/a/3233356/207209
+    '''
+    for k, v in u.items():
+        if isinstance(v, collections.abc.Mapping):
+            d[k] = recursive_update(d.get(k, {}), v)
+        else:
+            d[k] = v
+    return d
 
 def create_node_config_json(
     bootstrap_peers,
@@ -452,7 +466,8 @@ def create_node_config_json(
 ):
     """ Create the node's config.json file """
 
-    node_config = {
+    values_node_config = MY_NODE.get("config", {})
+    computed_node_config = {
         "data-dir": "/var/tezos/node/data",
         "rpc": {
             "listen-addrs": [f"{os.getenv('MY_POD_IP')}:8732", "127.0.0.1:8732"],
@@ -461,9 +476,9 @@ def create_node_config_json(
             "bootstrap-peers": bootstrap_peers,
             "listen-addr": (net_addr + ":9732" if net_addr else "[::]:9732"),
         },
-        "shell": MY_NODE.get("config", {}).get("shell", {}),
         # "log": {"level": "debug"},
     }
+    node_config = recursive_update(values_node_config, computed_node_config)
 
     if THIS_IS_A_PUBLIC_NET:
         node_config["network"] = NETWORK_CONFIG["chain_name"]

--- a/utils/config-generator.sh
+++ b/utils/config-generator.sh
@@ -7,7 +7,9 @@ echo ------------------------------------------------------------
 
 mkdir -p /var/tezos/client
 chmod -R 777 /var/tezos
+set -e
 python3 /config-generator.py "$@"
+set +e
 
 #
 # Next we write the current baker ccount into /etc/tezos/baking-account.

--- a/utils/wait-for-bootstrap.sh
+++ b/utils/wait-for-bootstrap.sh
@@ -10,20 +10,26 @@ if [ -s /var/tezos/node/peers.json ] && [ "$(jq length /var/tezos/node/peers.jso
     exit 0
 fi
 
-BOOTSTRAP_NODES=$(
+BAKING_BOOTSTRAP_NODES=$(
 	echo "$NODES" | \
 	    jq -r '.baking|to_entries[]
 		  |select(.value.is_bootstrap_node)
 		  |.key+".tezos-baking-node"'
 )
+REGULAR_BOOTSTRAP_NODES=$(
+	echo "$NODES" | \
+	    jq -r '.regular|to_entries[]
+		  |select(.value.is_bootstrap_node)
+		  |.key+".tezos-node"'
+)
 
-if [ -z "$BOOTSTRAP_NODES" ]; then
+if [ -z "$BAKING_BOOTSTRAP_NODES" ] && [ -z "$REGULAR_BOOTSTRAP_NODES" ]; then
     echo No bootstrap nodes were provided
     exit 1
 fi
 
 HOST=$(hostname -f)
-for node in $BOOTSTRAP_NODES; do
+for node in $BAKING_BOOTSTRAP_NODES $REGULAR_BOOTSTRAP_NODES; do
     if [ "${HOST##$node}" != "$HOST" ]; then
 	echo "I am $node!"
 	echo "I'm the one of the bootstrap nodes: do not wait for myself"
@@ -61,7 +67,7 @@ randomsleep() {
 echo "waiting for bootstrap nodes to accept connections"
 
 while :; do
-    for node in $BOOTSTRAP_NODES; do
+    for node in $BAKING_BOOTSTRAP_NODES $REGULAR_BOOTSTRAP_NODES; do
 	if </dev/null nc -q 0 ${node} 8732; then
 	    echo "$node is up"
 	    echo "Found bootstrap node, exiting"


### PR DESCRIPTION
* allow arbitrary config from values.yaml to be set in the node. This
  allow for setting private mode from values.yaml and this setting is
  transparently passed to the node config

* do not fail silently when generate-config.py crashes

* scour both regular and baking nodes for bootstrap nodes in
  wait-for-bootstrap. If you have only non-baking bootstrap nodes, the
  init script would otherwise fail.