### PR TITLE
fail init container when config-generator.py fails

### DIFF
--- a/utils/config-generator.sh
+++ b/utils/config-generator.sh
@@ -7,7 +7,9 @@ echo ------------------------------------------------------------
 
 mkdir -p /var/tezos/client
 chmod -R 777 /var/tezos
+set -e
 python3 /config-generator.py "$@"
+set +e
 
 #
 # Next we write the current baker ccount into /etc/tezos/baking-account.


### PR DESCRIPTION
This prevents silent failures which today cause node to start in mainnet
default configuration.