### PR TITLE
make activation idempotent

### DIFF
--- a/charts/tezos/scripts/chain-initiator.sh
+++ b/charts/tezos/scripts/chain-initiator.sh
@@ -4,9 +4,14 @@ until $CLIENT rpc get /version; do
     sleep 2
 done
 
-echo Activating chain:
 set -x
 set -o pipefail
+if ! $CLIENT rpc get /chains/main/blocks/head/header | grep '"level": 0,'; then
+    echo "Chain already activated, considering activation successful and exiting"
+    exit 0
+fi
+
+echo Activating chain:
 $CLIENT -d /var/tezos/client --block					\
 	genesis activate protocol					\
 	{{ .Values.activation.protocol_hash }}				\


### PR DESCRIPTION
If chain is already at level >0, assume activation has succeeded and
exit silently.

This will help deploying teztnets. Right now, any subsequent deploy
fails.

Unfortunately, I am parsing a json output with grep :(. Due to the
current way of doing everything with the tezos-node tools, I can't use
jq.

Tested locally on minikube by activating a chain from mkchain, then
deleting the job and doing `helm upgrade`. The job deployed again and
passed silently.