### PR TITLE
remote signer deployment

### DIFF
--- a/charts/tezos/scripts/remote-signer.sh
+++ b/charts/tezos/scripts/remote-signer.sh
@@ -1,0 +1,11 @@
+set -ex
+
+TEZ_VAR=/var/tezos
+TEZ_BIN=/usr/local/bin
+CLIENT_DIR="$TEZ_VAR/client"
+NODE_DIR="$TEZ_VAR/node"
+NODE_DATA_DIR="$TEZ_VAR/node/data"
+
+CMD="$TEZ_BIN/tezos-signer -d $CLIENT_DIR launch http signer -a 0.0.0.0 -p 6732"
+
+exec $CMD

--- a/charts/tezos/templates/signer.yaml
+++ b/charts/tezos/templates/signer.yaml
@@ -1,0 +1,65 @@
+{{- range  $key, $val := .Values.signers }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $.Values.signer_deployment.name }}-{{ $key }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ $.Values.signer_deployment.name }}-{{ $key }}
+  template:
+    metadata:
+      labels:
+        app: {{ $.Values.signer_deployment.name }}-{{ $key }}
+    spec:
+      containers:
+      - name: tezos-signer
+        image: "{{ $.Values.images.tezos }}"
+        ports:
+        - containerPort: 6732
+          name: signer
+        command:
+          - /bin/sh
+        volumeMounts:
+        - mountPath: /var/tezos
+          name: var-volume
+        args:
+          - "-c"
+          - |
+{{ tpl ($.Files.Get "scripts/remote-signer.sh") $ | indent 12 }}
+      initContainers:
+      - image: {{ $.Values.tezos_k8s_images.utils }}
+        imagePullPolicy: IfNotPresent
+        name: config-generator
+        args:
+          - "config-generator"
+        envFrom:
+          - secretRef:
+              name: tezos-secret
+          - configMapRef:
+              name: tezos-config
+        env:
+        volumeMounts:
+          - mountPath: /var/tezos
+            name: var-volume
+      securityContext:
+        fsGroup: 100
+      volumes:
+        - emptyDir: {}
+          name: var-volume
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $.Values.signer_deployment.name }}-{{ $key }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  clusterIP: None
+  ports:
+    - port: 6732
+      name: signer
+  selector:
+    app: {{ $.Values.signer_deployment.name }}-{{ $key }}
+---
+{{- end }}

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -26,6 +26,8 @@ regular_node_statefulset: # charts/tezos/templates/node.yaml
 tzkt_indexer_statefulset:
   name: tzkt-indexer
   storageClassName: ""
+signer_deployment:
+  name: tezos-signer
 
 # For non-public chains the defualt mutez given to an account if the
 # account is not explicitly set below.
@@ -82,6 +84,9 @@ nodes:
   baking: {}
     # tezos-baking-node-0:
       # bake_using_account: tqtezos_baker_0
+      # # bake_using_signer instructs the baker to connect to an external signing endpoint
+      # # (see "signers" object below)
+      # bake_using_signer: signer0
       # is_bootstrap_node: true
       # config:
       #   shell:
@@ -107,6 +112,10 @@ nodes:
       config:
         shell:
           history_mode: rolling
+
+# Define and use external remote signers.
+#signers:
+#  signer0: {}
 
 # Where full and rolling history mode nodes will get their snapshots from
 full_snapshot_url: https://mainnet.xtz-shots.io/full

--- a/mkchain/tqchain/mkchain.py
+++ b/mkchain/tqchain/mkchain.py
@@ -217,6 +217,7 @@ def main():
         BAKER_NODE_TYPE: {
             f"{BAKER_NODE_NAME}-{n}": {
                 "bake_using_account": f"baker{n}",
+                "bake_using_signer": "signer0",
                 "is_bootstrap_node": n < 2,
                 "config": {
                     "shell": {"history_mode": "archive" if n < 2 else "rolling"}
@@ -261,6 +262,7 @@ def main():
         "bootstrap_peers": bootstrap_peers,
         "accounts": accounts["secret"],
         "nodes": creation_nodes,
+        "signers": { "signer0": {} },
         **activation,
     }
 

--- a/mkchain/tqchain/mkchain.py
+++ b/mkchain/tqchain/mkchain.py
@@ -262,7 +262,7 @@ def main():
         "bootstrap_peers": bootstrap_peers,
         "accounts": accounts["secret"],
         "nodes": creation_nodes,
-        "signers": { "signer0": {} },
+        "signers": {"signer0": {}},
         **activation,
     }
 

--- a/utils/config-generator.sh
+++ b/utils/config-generator.sh
@@ -12,7 +12,7 @@ python3 /config-generator.py "$@"
 set +e
 
 #
-# Next we write the current baker ccount into /etc/tezos/baking-account.
+# Next we write the current baker account into /etc/tezos/baking-account.
 # We do it here because we shall use jq to process some of the environment
 # variables and we are not guaranteed to have jq available on an arbitrary
 # tezos docker image.


### PR DESCRIPTION
This creates a new values.yaml object `signers` deploying `tezos-signer`
daemons in pods in dedicated k8s deployment, and its associated service.

It is combined with a new annotation to the `baker` object called
`bake_using_signer`. It takes a value of the signer name. When set,
instead of native signing, the baker and enroser processes will connect
to the signing endpoint for every bake and endorse operation.

Example values.yaml config:

```
nodes:
  baking:
    tezos-baking-node-0:
      bake_using_account: baker0
      bake_using_signer: signer0
signers:
  signer0: {}
```

For now it does not limit the key deployment. Once we agree, in a later
PR, we can limit the private key exposure to the containers where they
are needed. But for now, every signer can see every key (just like every
baker can see every key in master).

mkchain will deploy one signer by default, and every baker will connect
to it. This is made standard as this is good practice.

Q: why signers are deployments while bakers are a stateful set?

A: tezos-signer is a very light process and a good fit for a deployment:
k8s will ensure there is always one (and just one) running at a time. If
there are several signers, we want similar guarantees for each since
(later) they will only sign for one given key.

Note: linting commit is separate since linting is apparently broken in master. Please check the first commit.
