### PR TITLE
remote signer statefulset

### DIFF
--- a/charts/tezos/scripts/remote-signer.sh
+++ b/charts/tezos/scripts/remote-signer.sh
@@ -1,0 +1,11 @@
+set -ex
+
+TEZ_VAR=/var/tezos
+TEZ_BIN=/usr/local/bin
+CLIENT_DIR="$TEZ_VAR/client"
+NODE_DIR="$TEZ_VAR/node"
+NODE_DATA_DIR="$TEZ_VAR/node/data"
+
+CMD="$TEZ_BIN/tezos-signer -d $CLIENT_DIR launch http signer -a 0.0.0.0 -p 6732"
+
+exec $CMD

--- a/charts/tezos/templates/_containers.tpl
+++ b/charts/tezos/templates/_containers.tpl
@@ -7,11 +7,11 @@
   valueFrom:
     fieldRef:
       fieldPath: metadata.name
-- name: MY_NODE_TYPE
+- name: MY_POD_TYPE
 {{- if contains "baker" .Template.Name }}
-  value: {{ .Values.baker_statefulset.node_type }}
+  value: {{ .Values.baker_statefulset.pod_type }}
 {{- else }}
-  value: {{ .Values.regular_node_statefulset.node_type }}
+  value: {{ .Values.regular_node_statefulset.pod_type }}
 {{- end }}
 {{- end }}
 

--- a/charts/tezos/templates/_helpers.tpl
+++ b/charts/tezos/templates/_helpers.tpl
@@ -54,6 +54,15 @@
 {{- end }}
 {{- end }}
 
+{{- define "tezos.shouldDeploySignerStatefulset" -}}
+{{- $signers := .Values.signers | default dict }}
+{{- if and (not .Values.is_invitation) ($signers | len) }}
+{{- "true" }}
+{{- else }}
+{{- "" }}
+{{- end }}
+{{- end }}
+
 {{/*
   Checks if a protocol should be activated. There needs to be a protocol_hash
   and protocol_parameters.

--- a/charts/tezos/templates/baker.yaml
+++ b/charts/tezos/templates/baker.yaml
@@ -18,7 +18,7 @@ spec:
             - |
 {{ tpl (.Files.Get "scripts/chain-initiator.sh") . | indent 14 }}
           imagePullPolicy: IfNotPresent
-          name: chain-initiator
+          name: {{ .Values.chain_initiator_job.name }}
           volumeMounts:
             - mountPath: /etc/tezos
               name: config-volume
@@ -44,6 +44,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: MY_POD_TYPE
+              value: {{ .Values.chain_initiator_job.pod_type }}
           volumeMounts:
             - mountPath: /etc/tezos
               name: config-volume

--- a/charts/tezos/templates/configs.yaml
+++ b/charts/tezos/templates/configs.yaml
@@ -15,6 +15,8 @@ data:
   ROLLING_SNAPSHOT_URL: "{{ .Values.rolling_snapshot_url }}"
   NODES: |
 {{ .Values.nodes | mustToPrettyJson | indent 4 }}
+  SIGNERS: |
+{{ .Values.signers | mustToPrettyJson | indent 4 }}
 kind: ConfigMap
 metadata:
   name: tezos-config

--- a/charts/tezos/templates/signer.yaml
+++ b/charts/tezos/templates/signer.yaml
@@ -1,0 +1,74 @@
+{{- if (include "tezos.shouldDeploySignerStatefulset" .) }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Values.signer_statefulset.name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  podManagementPolicy: Parallel
+  replicas: {{ .Values.signers | len }}
+  serviceName: {{ .Values.signer_statefulset.name }}
+  selector:
+    matchLabels:
+      app: {{ .Values.signer_statefulset.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.signer_statefulset.name }}
+    spec:
+      containers:
+      - name: tezos-signer
+        image: "{{ .Values.images.tezos }}"
+        ports:
+        - containerPort: 6732
+          name: signer
+        command:
+          - /bin/sh
+        volumeMounts:
+        - mountPath: /var/tezos
+          name: var-volume
+        args:
+          - "-c"
+          - |
+{{ tpl (.Files.Get "scripts/remote-signer.sh") $ | indent 12 }}
+      initContainers:
+      - image: {{ .Values.tezos_k8s_images.utils }}
+        imagePullPolicy: IfNotPresent
+        name: config-generator
+        args:
+          - "config-generator"
+        envFrom:
+          - secretRef:
+              name: tezos-secret
+          - configMapRef:
+              name: tezos-config
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_TYPE
+            value: {{ .Values.signer_statefulset.pod_type }}
+        volumeMounts:
+          - mountPath: /var/tezos
+            name: var-volume
+      securityContext:
+        fsGroup: 100
+      volumes:
+        - emptyDir: {}
+          name: var-volume
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.signer_statefulset.name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  clusterIP: None
+  ports:
+    - port: 6732
+      name: signer
+  selector:
+    app: {{ .Values.signer_statefulset.name }}
+---
+{{- end }}

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -117,7 +117,7 @@ nodes:
 # Define and use external remote signers.
 # Bakers automatically use signers when configured.
 signers: {}
-#  signer0:
+#  tezos-signer-0:
 #    sign_for_accounts:
 #    - baker0
 

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -17,15 +17,21 @@ tezos_k8s_images:
 # Properties that are templated in Helm template files
 baker_statefulset: # charts/tezos/templates/baker.yaml
   name: tezos-baking-node
-  node_type: baking
+  pod_type: baking
   storage_size: 15Gi
 regular_node_statefulset: # charts/tezos/templates/node.yaml
   name: tezos-node
-  node_type: regular
+  pod_type: regular
   storage_size: 15Gi
 tzkt_indexer_statefulset:
   name: tzkt-indexer
   storageClassName: ""
+signer_statefulset:
+  name: tezos-signer
+  pod_type: signing
+chain_initiator_job:
+  name: chain-initiator
+  pod_type: activating
 
 # For non-public chains the defualt mutez given to an account if the
 # account is not explicitly set below.
@@ -107,6 +113,13 @@ nodes:
       config:
         shell:
           history_mode: rolling
+
+# Define and use external remote signers.
+# Bakers automatically use signers when configured.
+signers: {}
+#  signer0:
+#    sign_for_accounts:
+#    - baker0
 
 # Where full and rolling history mode nodes will get their snapshots from
 full_snapshot_url: https://mainnet.xtz-shots.io/full

--- a/mkchain/tqchain/mkchain.py
+++ b/mkchain/tqchain/mkchain.py
@@ -232,6 +232,12 @@ def main():
             for n in range(args.number_of_nodes)
         }
 
+    signers = {
+        "tezos-signer-0": {
+            "sign_for_accounts": [f"baker{n}" for n in range(args.number_of_bakers)]
+        }
+    }
+
     first_baker_node_name = next(iter(creation_nodes[BAKER_NODE_TYPE]))
     activation_account_name = creation_nodes[BAKER_NODE_TYPE][first_baker_node_name][
         "bake_using_account"
@@ -260,6 +266,7 @@ def main():
         **base_constants,
         "bootstrap_peers": bootstrap_peers,
         "accounts": accounts["secret"],
+        "signers": signers,
         "nodes": creation_nodes,
         **activation,
     }

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -270,6 +270,8 @@ def import_keys(all_accounts):
         remote_signers_for_account = [
             k for k, v in SIGNERS.items() if account_name in v["sign_for_accounts"]
         ]
+        # pick the signer for the account, if any.
+        # if several signers sign for this account, pick the first one
         if MY_POD_TYPE == "baking" and len(remote_signers_for_account) > 0:
             remote_signer_url = f"http://{remote_signers_for_account[0]}.tezos-signer:6732/{key.public_key_hash()}"
         try:

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -21,11 +21,11 @@ SIGNERS = json.loads(os.environ["SIGNERS"])
 
 MY_POD_NAME = os.environ["MY_POD_NAME"]
 MY_POD_TYPE = os.environ["MY_POD_TYPE"]
-MY_NODE = None
+MY_POD_CONFIG = None
 if MY_POD_TYPE == "signing":
-    MY_NODE = SIGNERS[MY_POD_NAME]
+    MY_SIGNER = SIGNERS[MY_POD_NAME]
 elif MY_POD_TYPE in ["baking", "regular"]:
-    MY_NODE = NODES[MY_POD_TYPE][MY_POD_NAME]
+    MY_POD_CONFIG = NODES[MY_POD_TYPE][MY_POD_NAME]
 
 
 ALL_NODES = {**NODES.get("baking", {}), **NODES.get("regular", {})}
@@ -115,7 +115,7 @@ def main():
                     local_bootstrap_peers.append(bootstrap_peer_fbn_with_port)
             bootstrap_peers.extend(local_bootstrap_peers)
 
-        if not bootstrap_peers and not MY_NODE.get("is_bootstrap_node", False):
+        if not bootstrap_peers and not MY_POD_CONFIG.get("is_bootstrap_node", False):
             raise Exception(
                 "ERROR: No bootstrap peers found for this non-bootstrap node"
             )
@@ -185,7 +185,7 @@ def fill_in_missing_baker_accounts():
 
 # Verify that the current baker has a baker account with secret key
 def verify_this_bakers_account(accounts):
-    account_using_to_bake = MY_NODE.get("bake_using_account")
+    account_using_to_bake = MY_POD_CONFIG.get("bake_using_account")
     if not account_using_to_bake:
         raise Exception(f"ERROR: No account specified for baker {MY_POD_NAME}")
 
@@ -295,11 +295,11 @@ def import_keys(all_accounts):
             )
             or (
                 MY_POD_TYPE == "baking"
-                and MY_NODE.get("bake_using_account") == account_name
+                and MY_POD_CONFIG.get("bake_using_account") == account_name
             )
             or (
                 MY_POD_TYPE == "signing"
-                and account_name in MY_NODE.get("sign_for_accounts")
+                and account_name in MY_POD_CONFIG.get("sign_for_accounts")
             )
         ):
             try:
@@ -499,7 +499,7 @@ def create_node_config_json(
 ):
     """Create the node's config.json file"""
 
-    values_node_config = MY_NODE.get("config", {})
+    values_node_config = MY_POD_CONFIG.get("config", {})
     computed_node_config = {
         "data-dir": "/var/tezos/node/data",
         "rpc": {

--- a/utils/config-generator.sh
+++ b/utils/config-generator.sh
@@ -12,14 +12,14 @@ python3 /config-generator.py "$@"
 set +e
 
 #
-# Next we write the current baker ccount into /etc/tezos/baking-account.
+# Next we write the current baker account into /etc/tezos/baking-account.
 # We do it here because we shall use jq to process some of the environment
 # variables and we are not guaranteed to have jq available on an arbitrary
 # tezos docker image.
 
-if [ "$MY_NODE_TYPE" = "baking" ]; then
+if [ "$MY_POD_TYPE" = "baking" ]; then
     my_baker_account=$(echo $NODES | \
-	    jq -r ".${MY_NODE_TYPE}.\"${MY_POD_NAME}\".bake_using_account")
+	    jq -r ".${MY_POD_TYPE}.\"${MY_POD_NAME}\".bake_using_account")
 
     # If no account to bake for was specified in the node's settings,
     # config-generator defaults the account name to the pod's name.

--- a/utils/snapshot-downloader.sh
+++ b/utils/snapshot-downloader.sh
@@ -6,7 +6,7 @@ node_data_dir="$node_dir/data"
 snapshot_file=$node_dir/chain.snapshot
 
 my_nodes_history_mode=$(echo $NODES |
-	jq -r ".$MY_NODE_TYPE.\"$MY_POD_NAME\".config.shell.history_mode")
+	jq -r ".$MY_POD_TYPE.\"$MY_POD_NAME\".config.shell.history_mode")
 
 case "$my_nodes_history_mode" in
         full)           snapshot_url="$FULL_SNAPSHOT_URL"       ;;

--- a/zerotier/entrypoint.sh
+++ b/zerotier/entrypoint.sh
@@ -32,7 +32,7 @@ do
 done
 
 echo "Set zerotier name"
-if [ "$(echo $NODES | jq -r ".${MY_NODE_TYPE}.\"${MY_POD_NAME}\".is_bootstrap_node")" == "true" ]; then
+if [ "$(echo $NODES | jq -r ".${MY_POD_TYPE}.\"${MY_POD_NAME}\".is_bootstrap_node")" == "true" ]; then
   zerotier_name="${CHAIN_NAME}_bootstrap"
   zerotier_description="Bootstrap node ${MY_POD_NAME} for chain ${CHAIN_NAME}"
 else


### PR DESCRIPTION
This creates a new values.yaml object `signers` deploying `tezos-signer` daemons in pods in dedicated k8s statefulset.

Signers are associated with accounts with the syntax: "sign_for_account": list of accounts.

When a signer is found with relevant "sign_for_account", the baker will automatically configure itself to use it.

Example values.yaml config:

```
nodes:
  baking:
    tezos-baking-node-0:
      bake_using_account: baker0
      is_bootstrap_node: true
    tezos-baking-node-1:
      bake_using_account: baker1
      is_bootstrap_node: true
  regular: null
signers:
  tezos-signer-0:
    sign_for_accounts:
    - baker0
    - baker1
```

In this PR, we also limit the private key exposure to the containers where they are needed. Private keys only go to the baker if needed, or to the signer if needed, based on values.yaml config.

mkchain will deploy one signer by default, and every baker will connect to it. This is made standard as this is good practice.

We also replace `MY_NODE_NAME` with `MY_POD_NAME` since the signer also populates this env var in order to help config generator to generate the right config.

Previously, config-generator.py relied on `MY_NODE_NAME` being unset to detect whether it was running inside the activation pod. We have now made it explicit by setting `MY_POD_NAME` to `activating` in the activation pod.

This PR also fixes some linting issues that are in master now.