### PR TITLE
fix #227 handle the new ACL setting

### DIFF
--- a/charts/tezos/templates/configs.yaml
+++ b/charts/tezos/templates/configs.yaml
@@ -17,6 +17,7 @@ data:
 {{ .Values.nodes | mustToPrettyJson | indent 4 }}
   SIGNERS: |
 {{ .Values.signers | mustToPrettyJson | indent 4 }}
+  OPEN_ACLS: "{{ .Values.open_acls }}"
 kind: ConfigMap
 metadata:
   name: tezos-config

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -14,6 +14,14 @@ tezos_k8s_images:
   utils: tezos-k8s-utils:dev
   zerotier: tezos-k8s-zerotier:dev
 
+# octez v11 or superior requires explicitly opening up ACLs for other
+# containers to be able to do sentitive RPC operations to it
+# for example chain activation
+#
+# But v10 or less does not recognize the argument.
+# Set this toggle to true when using octez v11.
+open_acls: false
+
 # Properties that are templated in Helm template files
 baker_statefulset: # charts/tezos/templates/baker.yaml
   name: tezos-baking-node

--- a/utils/config-generator.py
+++ b/utils/config-generator.py
@@ -18,6 +18,7 @@ ACCOUNTS = json.loads(os.environ["ACCOUNTS"])
 CHAIN_PARAMS = json.loads(os.environ["CHAIN_PARAMS"])
 NODES = json.loads(os.environ["NODES"])
 SIGNERS = json.loads(os.environ["SIGNERS"])
+OPEN_ACLS = os.environ["OPEN_ACLS"]
 
 MY_POD_NAME = os.environ["MY_POD_NAME"]
 MY_POD_TYPE = os.environ["MY_POD_TYPE"]
@@ -503,6 +504,8 @@ def create_node_config_json(
         },
         # "log": {"level": "debug"},
     }
+    if OPEN_ACLS == "true":
+        computed_node_config["rpc"]["acl"] = [ { "address": os.getenv('MY_POD_IP'), "blacklist": [] } ]
     node_config = recursive_update(values_node_config, computed_node_config)
 
     if THIS_IS_A_PUBLIC_NET:


### PR DESCRIPTION
To run octez master branch, it's necessary to put the following setting
in values.yaml

```
open_acls: true
```

This will configure the baking nodes as follows:

```
  "rpc": {
    "listen-addrs": [
      "172.17.0.7:8732",
      "127.0.0.1:8732"
    ],
    "acl": [
      {
        "address": "172.17.0.7",
        "blacklist": []
      }
    ]
```

The above configuration is needed for chain activation, since the
activation operation uses RPCs which are blacklisted by default.

The ACL setting needs to be set with the listen addr, so it's not
possible to pass it as a node config with values.yaml. It has to be
generated on the fly. We pass the flag to config-generator.py which adds
the setting.

When set to `true`, this toggle will break octez v9/10 since it will not
recognize an `acl` object in `config/rpc`.

The toggle will go away at some point (when v9/v10 is no longer used)