### PR TITLE
Allow for multiple baking accounts per baker

### DIFF
--- a/mkchain/tqchain/mkchain.py
+++ b/mkchain/tqchain/mkchain.py
@@ -135,7 +135,7 @@ def node_config(name, n, is_baker):
         },
     }
     if is_baker:
-        ret["bake_using_account"] = f"{name}-{n}"
+        ret["bake_using_accounts"] = [f"{name}-{n}"]
         if n < 2:
             ret["is_bootstrap_node"] = True
             ret["config"]["shell"]["history_mode"] = "archive"

--- a/utils/config-generator.sh
+++ b/utils/config-generator.sh
@@ -52,7 +52,10 @@ AM_I_BAKER=$(echo $MY_CLASS | jq -r '.runs|map(select(. == "baker"))|length')
 if [ "$AM_I_BAKER" -eq 1 ]; then
     my_baker_account=$(echo $MY_CLASS | \
 	    jq -r ".instances[${MY_POD_NAME#$MY_NODE_CLASS-}]
-		   .bake_using_account")
+		   |if .bake_using_accounts
+		    then .bake_using_accounts[]
+		    else .bake_using_account
+		    end")
 
     # If no account to bake for was specified in the node's settings,
     # config-generator defaults the account name to the pod's name.


### PR DESCRIPTION
As requested in Issue #214, we implement multiple baker accounts per
baker.  We update the definition of instances in the node section
to allow:

  tezos-baking-node:
    runs:
    - baker
    - endorser
    storage_size: 15Gi
    instances:
    - bake_using_accounts:
      - baker0.0
      - baker0.1
      - baker0.2
      config:
        shell:
          history_mode: full
      is_bootstrap_node: true

If "bake_using_accounts" is provided, then it is interpreted as a list
of accounts.  The will be automatically created if they don't exist when
"should_generate_unsafe_deterministic_data" is true.

"bake_using_account" is still honoured.  It is an error to specify both.

mkchain still makes parameters files using "bake_using_account" so that
we can use a newer mkchain with slightly older charts.  We expect to
deprecate this and update in the future.