### PR TITLE
Update helm chart ref and change tqtezos to oa

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,16 +173,16 @@ jobs:
 
           curl -s -H "Authorization: JWT ${TOKEN}" "https://hub.docker.com/v2/repositories/" \
           --data 'description="tezos-k8s ${{ matrix.container }}"' \
-          --data 'full_description="The container for https://github.com/tqtezos/tezos-k8s/tree/master/${{ matrix.container }}' \
+          --data 'full_description="The container for https://github.com/oxheadalpha/tezos-k8s/tree/master/${{ matrix.container }}' \
           --data 'is_private=false' \
           --data 'name=tezos-k8s-${{ matrix.container }}' \
-          --data "namespace=tqtezos" || true
+          --data "namespace=oxheadalpha" || true
 
       - name: Docker meta
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v1
         with:
-          images: tqtezos/tezos-k8s-${{ matrix.container }}
+          images: oxheadalpha/tezos-k8s-${{ matrix.container }}
           tag-sha: true
 
       - name: Publish ${{ matrix.container }} container to Docker Hub
@@ -238,13 +238,13 @@ jobs:
             # Update Chart.yaml with release version
             yq e ".version = \"$RELEASE_VERSION\"" -i "$chart/Chart.yaml"
 
-            # Get tqtezos/tezos-k8s images specified in values.yaml
+            # Get oxheadalpha/tezos-k8s images specified in values.yaml
             tq_images=$(yq e '(.tezos_k8s_images[]) | path | .[-1]' "$chart/values.yaml")
 
             # Update the release version of each of tezos-k8s images
             for image in $tq_images; do
               image_name=$(yq e ".tezos_k8s_images.$image" $chart/values.yaml | sed -E "s/tezos-k8s-(.*):.*/\1/")
-              yq e ".tezos_k8s_images.$image = \"tqtezos/tezos-k8s-$image_name:$RELEASE_VERSION\"" -i $chart/values.yaml
+              yq e ".tezos_k8s_images.$image = \"oxheadalpha/tezos-k8s-$image_name:$RELEASE_VERSION\"" -i $chart/values.yaml
             done
           done
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -32,7 +32,7 @@
 - Tell devspace which namespace to use:
 
   ```shell
-  devspace use namespace tqtezos
+  devspace use namespace oxheadalpha
   ```
 
 - Run `mkchain` to generate your Helm values. (Note: Devspace will only deploy `rpc-auth` if you use the `rpc-auth` profile, regardless if you set it in mkchain. This is to avoid devspace deployment issues. See more below.)
@@ -75,14 +75,14 @@ Chart.yaml does not require an `appVersion`. So we are not using it as it doesn'
 
 Regarding chart dependencies, Chart.yaml should not specify a dependency version for another _local_ chart.
 
-Being that all charts are bumped to the same version on release, the parent chart will get the latest version of the dependency by default (which is the same as its own version) when installing via our Helm chart [repo](https://github.com/tqtezos/tezos-helm-charts).
+Being that all charts are bumped to the same version on release, the parent chart will get the latest version of the dependency by default (which is the same as its own version) when installing via our Helm chart [repo](https://github.com/oxheadalpha/tezos-helm-charts).
 
 ## Run local development chart
 
 Instructions as per README install the latest release of tezos-k8s helm chart from a helm repository. To install a development version of a tezos chart in the charts/tezos directory instead, run:
 
 ```
-helm install tezos-mainnet charts/tezos --namespace tqtezos --create-namespace
+helm install tezos-mainnet charts/tezos --namespace oxheadalpha --create-namespace
 ```
 
 ## Notes
@@ -97,7 +97,7 @@ Here is an example of the flow for creating new images and how they are publishe
 
 - You are creating a new image that you call `chain-initiator`. Name its folder `chain-initiator`. This folder should contain at least a `Dockerfile`.
 
-- The CI on release will pre-pend `tezos-k8s` to the folder name, so `tezos-k8s-chain-initiator`. That is what the image will be named on Docker Hub under the `tqtezos` repo. So you would pull/push `tqtezos/tezos-k8s-chain-initiator`. All of our image names will have this format.
+- The CI on release will pre-pend `tezos-k8s` to the folder name, so `tezos-k8s-chain-initiator`. That is what the image will be named on Docker Hub under the `oxheadalpha` repo. So you would pull/push `oxheadalpha/tezos-k8s-chain-initiator`. All of our image names will have this format.
 
 - In Helm charts that will be using the new image, set in the `values.yaml` file under the field `tezos_k8s_images` the value of `tezos-k8s-chain-initiator:dev`. (Any other images that a chart uses that it just pulls from a remote registry should go under the `images` field.) This is how the file will be stored in version control. On releases, the CI will set the tags to the release version and publish that to Docker Hub.
 
@@ -117,6 +117,6 @@ Upon release, every component of the tezos-k8s repo will be bumped to that versi
 
 - mkchain will be published to pypi
 - Docker images will be deployed to Docker Hub
-- Helm charts will be deployed to our Github Pages [repo](https://github.com/tqtezos/tezos-helm-charts)
+- Helm charts will be deployed to our Github Pages [repo](https://github.com/oxheadalpha/tezos-helm-charts)
 
 See the Github CI file [./.github/workflows/ci.yml](.github/workflows/ci.yml) for our full CI pipeline.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
-- [Prerequisites](#prerequisites)
-- [Installing prerequisites](#installing-prerequisites)
-  - [Mac](#mac)
-  - [Arch Linux](#arch-linux)
-  - [Other Operating Systems](#other-operating-systems)
-- [Configuring Minikube](#configuring-minikube)
-  - [Mac](#mac-1)
-  - [Other Operating Systems](#other-operating-systems-1)
-- [Starting Minikube](#starting-minikube)
-- [Tezos k8s Helm Chart](#tezos-k8s-helm-chart)
+- [Tezos k8s](#tezos-k8s)
+  - [Prerequisites](#prerequisites)
+  - [Installing prerequisites](#installing-prerequisites)
+    - [Mac](#mac)
+    - [Arch Linux](#arch-linux)
+    - [Other Operating Systems](#other-operating-systems)
+  - [Configuring Minikube](#configuring-minikube)
+    - [Mac](#mac-1)
+    - [Other Operating Systems](#other-operating-systems-1)
+  - [Starting Minikube](#starting-minikube)
+  - [Tezos k8s Helm Chart](#tezos-k8s-helm-chart)
 - [Joining Mainnet](#joining-mainnet)
   - [Spinning Up a Regular Peer Node](#spinning-up-a-regular-peer-node)
 - [Creating a Private Blockchain](#creating-a-private-blockchain)
@@ -126,7 +127,7 @@ eval $(minikube docker-env -u)
 To add the Tezos k8s Helm chart to your local Helm chart repo, run:
 
 ```shell
-helm repo add tqtezos https://tqtezos.github.io/tezos-helm-charts
+helm repo add oxheadalpha https://oxheadalpha.github.io/tezos-helm-charts/
 ```
 
 # Joining Mainnet
@@ -140,15 +141,15 @@ Connecting to a public net is easy!
 If you'd like to spin up a node that runs with history mode rolling, all you need to do is run:
 
 ```shell
-helm install tezos-mainnet tqtezos/tezos-chain \
---namespace tqtezos --create-namespace
+helm install tezos-mainnet oxheadalpha/tezos-chain \
+--namespace oxheadalpha --create-namespace
 ```
 
 If you'd like to spin up a node with history mode full, run:
 
 ```shell
-helm install tezos-mainnet tqtezos/tezos-chain \
---namespace tqtezos --create-namespace \
+helm install tezos-mainnet oxheadalpha/tezos-chain \
+--namespace oxheadalpha --create-namespace \
 --set nodes.regular.tezos-node-0.config.shell.history_mode=full
 ```
 
@@ -158,22 +159,22 @@ Running either of these commands results in:
 - k8s will spin up one regular (i.e. non-baking node) which will download and import a mainnet snapshot. This will take a few minutes.
 - Once the snapshot step is done, your node will be bootstrapped and syncing with mainnet!
 
-You can find your node in the tqtezos namespace with some status information using `kubectl`.
+You can find your node in the oxheadalpha namespace with some status information using `kubectl`.
 
 ```shell
-kubectl -n tqtezos get pods -l appType=tezos-node
+kubectl -n oxheadalpha get pods -l appType=tezos-node
 ```
 
 You can monitor (and follow using the `-f` flag) the logs of the snapshot downloader/import container:
 
 ```shell
-kubectl logs -n tqtezos statefulset/tezos-node -c snapshot-downloader -f
+kubectl logs -n oxheadalpha statefulset/tezos-node -c snapshot-downloader -f
 ```
 
 You can view logs for your node using the following command:
 
 ```shell
-kubectl -n tqtezos logs -l appType=tezos-node -c tezos-node -f --prefix
+kubectl -n oxheadalpha logs -l appType=tezos-node -c tezos-node -f --prefix
 ```
 
 IMPORTANT:
@@ -263,9 +264,9 @@ The former is what you will use to create your chain, and the latter is for invi
 Create a Helm release that will start your chain:
 
 ```shell
-helm install $CHAIN_NAME tqtezos/tezos-chain \
+helm install $CHAIN_NAME oxheadalpha/tezos-chain \
 --values ./${CHAIN_NAME}_values.yaml \
---namespace tqtezos --create-namespace
+--namespace oxheadalpha --create-namespace
 ```
 
 Your kubernetes cluster will now be running a series of jobs to
@@ -279,16 +280,16 @@ perform the following tasks:
 - activate the protocol
 - bake the first block
 
-You can find your node in the tqtezos namespace with some status information using kubectl.
+You can find your node in the oxheadalpha namespace with some status information using kubectl.
 
 ```shell
-kubectl -n tqtezos get pods -l appType=tezos-node
+kubectl -n oxheadalpha get pods -l appType=tezos-node
 ```
 
 You can view (and follow using the `-f` flag) logs for your node using the following command:
 
 ```shell
-kubectl -n tqtezos logs -l appType=tezos-node -c tezos-node -f --prefix
+kubectl -n oxheadalpha logs -l appType=tezos-node -c tezos-node -f --prefix
 ```
 
 Congratulations! You now have an operational Tezos based permissioned
@@ -319,14 +320,14 @@ IMPORTANT: If you are manually editing the values yaml file, you must make sure 
 To upgrade your Helm release run:
 
 ```shell
-helm upgrade $CHAIN_NAME tqtezos/tezos-chain \
+helm upgrade $CHAIN_NAME oxheadalpha/tezos-chain \
 --values ./${CHAIN_NAME}_values.yaml \
---namespace tqtezos
+--namespace oxheadalpha
 ```
 
 The nodes will start up and establish peer-to-peer connections in a full mesh topology.
 
-List all of your running nodes: `kubectl -n tqtezos get pods -l appType=tezos-node`
+List all of your running nodes: `kubectl -n oxheadalpha get pods -l appType=tezos-node`
 
 ## Adding external nodes to the cluster
 
@@ -347,11 +348,11 @@ The member needs to:
 Then run:
 
 ```shell
-helm repo add tqtezos https://tqtezos.github.io/tezos-helm-charts
+helm repo add oxheadalpha https://oxheadalpha.github.io/tezos-helm-charts
 
-helm install $CHAIN_NAME tqtezos/tezos-chain \
+helm install $CHAIN_NAME oxheadalpha/tezos-chain \
 --values <LOCATION OF ${CHAIN_NAME}_invite_values.yaml> \
---namespace tqtezos --create-namespace
+--namespace oxheadalpha --create-namespace
 ```
 
 At this point additional nodes will be added in a full mesh
@@ -362,9 +363,9 @@ Congratulations! You now have a multi-node Tezos based permissioned chain.
 On each computer, run this command to check that the nodes have matching heads by comparing their hashes (it may take a minute for the nodes to sync up):
 
 ```shell
-kubectl get pod -n tqtezos -l appType=tezos-node -o name |
+kubectl get pod -n oxheadalpha -l appType=tezos-node -o name |
 while read line;
-  do kubectl -n tqtezos exec $line -c tezos-node -- /usr/local/bin/tezos-client rpc get /chains/main/blocks/head/hash;
+  do kubectl -n oxheadalpha exec $line -c tezos-node -- /usr/local/bin/tezos-client rpc get /chains/main/blocks/head/hash;
 done
 ```
 
@@ -382,7 +383,7 @@ Current supported indexers:
 
 - [TzKT](https://github.com/baking-bad/tzkt)
 
-Look [here](https://github.com/tqtezos/tezos-k8s/blob/master/charts/tezos/values.yaml#L184-L205) in the Tezos Helm chart's values.yaml `indexer` section for how to deploy an indexer.
+Look [here](https://github.com/oxheadalpha/tezos-k8s/blob/master/charts/tezos/values.yaml#L184-L205) in the Tezos Helm chart's values.yaml `indexer` section for how to deploy an indexer.
 
 You must spin up an archive node in your cluster if you want to your indexer to index it. You would do so by configuring a new node's `history_mode` to be `archive`.
 

--- a/charts/rpc-auth/Chart.yaml
+++ b/charts/rpc-auth/Chart.yaml
@@ -6,4 +6,4 @@ version: 0.0.0
 keywords:
   - tezos
   - blockchain
-home: https://github.com/tqtezos/tezos-k8s
+home: https://github.com/oxheadalpha/tezos-k8s

--- a/charts/tezos/Chart.yaml
+++ b/charts/tezos/Chart.yaml
@@ -6,4 +6,4 @@ version: 0.0.0
 keywords:
   - tezos
   - blockchain
-home: https://github.com/tqtezos/tezos-k8s
+home: https://github.com/oxheadalpha/tezos-k8s

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -57,13 +57,13 @@ should_generate_unsafe_deterministic_data: false
 #   balance, it will default to the `bootstrap_mutez` field above.
 #
 accounts: {}
-#   tqtezos_baker_0:
+#   oxheadalpha_baker_0:
 #     key: edsk...
 #     type: secret
 #     is_bootstrap_baker_account: true
 #     bootstrap_balance: "50000000000000"
 
-#   tqtezos_regular_account_0:
+#   oxheadalpha_regular_account_0:
 #     key: edpk...
 #     type: public
 #     is_bootstrap_baker_account: false
@@ -148,7 +148,7 @@ expected_proof_of_work: 26
 #     protocol: PtYuensgYBb3G3x1hLLbCmcav8ue8Kyd2khADcL5LsT5R1hcXex
 #   # The name of the account who's public key will be set downstream in
 #   # config.json at `network.genesis_parameters.values.genesis_pubkey`.
-#   activation_account_name: tqtezos_baker_0
+#   activation_account_name: oxheadalpha_baker_0
 #
 ## For joining a public network:
 ## - If specifying the name of the network, the network's name must be

--- a/mkchain/README.md
+++ b/mkchain/README.md
@@ -96,13 +96,13 @@ You can explicitly specify some values by:
 Make sure you have the Tezos Helm chart repo:
 
 ```shell
-helm repo add tqtezos https://tqtezos.github.io/tezos-helm-charts
+helm repo add oxheadalpha https://oxheadalpha.github.io/tezos-helm-charts
 ```
 
 Then install the Tezos Helm chart:
 
 ```shell
-helm install $CHAIN_NAME tqtezos/tezos-chain \
+helm install $CHAIN_NAME oxheadalpha/tezos-chain \
 --values ./${CHAIN_NAME}_values.yaml \
---namespace tqtezos --create-namespace
+--namespace oxheadalpha --create-namespace
 ```

--- a/mkchain/setup.py
+++ b/mkchain/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     description="A utility to generate k8s configs for a Tezos blockchain",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/tqtezos/tezos-k8s",
+    url="https://github.com/oxheadalpha/tezos-k8s",
     include_package_data=True,
     install_requires=["pyyaml"],
     setup_requires=["wheel"],

--- a/rpc-auth/README.md
+++ b/rpc-auth/README.md
@@ -40,7 +40,7 @@ helm upgrade $CHAIN_NAME oxheadalpha/tezos-chain \
 
 ### Prerequisites
 
-- [tezos-client](https://assets.oxheadalpha.com/docs/setup/1-tezos-client/)
+- [tezos-client](https://assets.tqtezos.com/docs/setup/1-tezos-client/)
 
 ## Authentication flow
 

--- a/rpc-auth/README.md
+++ b/rpc-auth/README.md
@@ -1,7 +1,8 @@
-- [Deploy RPC Auth Backend](#deploy-rpc-auth-backend)
-- [Client Authentication](#client-authentication)
-  - [Prerequisites](#prerequisites)
-- [Authentication flow](#authentication-flow)
+- [Tezos RPC Authentication](#tezos-rpc-authentication)
+  - [Deploy RPC Auth Backend](#deploy-rpc-auth-backend)
+  - [Client Authentication](#client-authentication)
+    - [Prerequisites](#prerequisites)
+  - [Authentication flow](#authentication-flow)
 
 # Tezos RPC Authentication
 
@@ -16,30 +17,30 @@ This assumes that you have followed the steps [here](../README.md) necessary to 
 Make sure you have the Tezos Helm chart repo:
 
 ```shell
-helm repo add tqtezos https://tqtezos.github.io/tezos-helm-charts
+helm repo add oxheadalpha https://oxheadalpha.github.io/tezos-helm-charts
 ```
 
 If you don't currently have a chain running, run the following command to start it:
 
 ```shell
-helm install $CHAIN_NAME tqtezos/tezos-chain \
+helm install $CHAIN_NAME oxheadalpha/tezos-chain \
 --values ./${CHAIN_NAME}_values.yaml \
---namespace tqtezos --create-namespace
+--namespace oxheadalpha --create-namespace
 ```
 
 If you already have a chain running, you need to use Helm's `upgrade` cmd instead of `install`:
 
 ```shell
-helm upgrade $CHAIN_NAME tqtezos/tezos-chain \
+helm upgrade $CHAIN_NAME oxheadalpha/tezos-chain \
 --values ./${CHAIN_NAME}_values.yaml \
---namespace tqtezos
+--namespace oxheadalpha
 ```
 
 ## Client Authentication
 
 ### Prerequisites
 
-- [tezos-client](https://assets.tqtezos.com/docs/setup/1-tezos-client/)
+- [tezos-client](https://assets.oxheadalpha.com/docs/setup/1-tezos-client/)
 
 ## Authentication flow
 
@@ -48,10 +49,10 @@ helm upgrade $CHAIN_NAME tqtezos/tezos-chain \
 
    - Run
      ```shell
-     kubectl exec -it -n tqtezos statefulset/tezos-baking-node -c tezos-node -- tezos-client rpc get /chains/main/chain_id
+     kubectl exec -it -n oxheadalpha statefulset/tezos-baking-node -c tezos-node -- tezos-client rpc get /chains/main/chain_id
      ```
    - Use a tool like [Lens](https://k8slens.dev/) to view the logs of the Tezos node. (As well as the rest of your k8s infrastructure)
-   - Manually run the logs command `kubectl logs -n tqtezos statefulset/tezos-baking-node -c tezos-node`. The top of the logs should look similar to:
+   - Manually run the logs command `kubectl logs -n oxheadalpha statefulset/tezos-baking-node -c tezos-node`. The top of the logs should look similar to:
      ```
      Dec 21 19:42:08 - node.main: starting the Tezos node (chain = my-chain)
      Dec 21 19:42:08 - node.main: disabled local peer discovery


### PR DESCRIPTION
tezos-helm-charts has been migrated to oxheadalpha github org.

https://github.com/oxheadalpha/tezos-helm-charts

This PR updates the readme of any mentions to the old repo location to the new repo location and also changes any mentions of `tqtezos` to `oxheadalpha`.